### PR TITLE
include all respondsToSelector checks

### DIFF
--- a/prefs.xm
+++ b/prefs.xm
@@ -276,8 +276,10 @@ static void pl_lazyLoadBundleCore(id self, SEL _cmd, PSSpecifier *specifier, voi
 		result = [result initForContentSize:[[self view] bounds].size];
 	else
 		result = [result init];
-	[result setRootController:self.rootController];
-	[result setParentController:self];
+	if ([result respondsToSelector:@selector(setRootController:)])
+		[result setRootController:self.rootController];
+	if ([result respondsToSelector:@selector(setParentController:)])
+		[result setParentController:self];
 	if ([result respondsToSelector:@selector(setSpecifier:)])
 		[result setSpecifier:specifier];
 	else if ([result isKindOfClass:[PSListController class]]) {


### PR DESCRIPTION
prevents crash in certain cases